### PR TITLE
Typings

### DIFF
--- a/dist/types/createContextHistory.d.ts
+++ b/dist/types/createContextHistory.d.ts
@@ -1,0 +1,11 @@
+export function createContextHistory(): {
+    readonly entries: IterableIterator<any>;
+    readonly size: number;
+    /**
+     * @param {"function" | "set"} type
+     * @param {string | number | symbol} name
+     * @param {unknown} args
+     */
+    push(type: "function" | "set", name: string | number | symbol, args: unknown): void;
+    clear(): void;
+};

--- a/dist/types/createObservableContext.d.ts
+++ b/dist/types/createObservableContext.d.ts
@@ -1,0 +1,5 @@
+/**
+ * @param {CanvasRenderingContext2D} baseContext
+ * @param {ReturnType<typeof import("./createContextHistory").createContextHistory>['push']} observe
+ */
+export function createObservableContext(baseContext: CanvasRenderingContext2D, observe: ReturnType<typeof import("./createContextHistory").createContextHistory>['push']): CanvasRenderingContext2D;

--- a/dist/types/defaults.d.ts
+++ b/dist/types/defaults.d.ts
@@ -1,0 +1,11 @@
+declare namespace _default {
+    export const target: HTMLElement;
+    export const viewBox: number[];
+    export const autoAspectRatio: boolean;
+    export const scaleMode: string;
+    export const resolution: number;
+    const _static: boolean;
+    export { _static as static };
+    export const id: number;
+}
+export default _default;

--- a/dist/types/domUtils.d.ts
+++ b/dist/types/domUtils.d.ts
@@ -1,0 +1,10 @@
+export function resolveTarget(target: any): any;
+export function createCanvasHTMLElement(id: any): HTMLCanvasElement;
+/** @param {HTMLCanvasElement} canvasHTMLElement */
+export function getCanvasContext(canvasHTMLElement: HTMLCanvasElement): CanvasRenderingContext2D;
+/**
+ * @param {HTMLElement} target
+ * @param {HTMLCanvasElement} el
+ */
+export function mountCanvasToDOM(target: HTMLElement, el: HTMLCanvasElement): void;
+export function randomID(): string;

--- a/dist/types/index.d.ts
+++ b/dist/types/index.d.ts
@@ -1,0 +1,42 @@
+export type CreateCanvasOptions = {
+    /**
+     * Where to add the `<canvas>` element in the DOM.
+     */
+    target?: HTMLElement;
+    /**
+     * Canvas viewbox (x, y, w, h). Mirrors SVG Behaviour.
+     */
+    viewBox?: [x: number, y: number, w: number, h: number];
+    /**
+     * Match DOM dimensions to `viewBox`. When true, `<canvas>` elements behave in a similar way to `<svg>`.
+     */
+    autoAspectRatio?: boolean;
+    /**
+     * VBCanvas's version of `preserveAspectRatio`. Accepts `fit` or `fill`. `fit` is equal to SVG'sxMidYMid meet. `fill` is equal to SVG'sxMidYMid slice.
+     */
+    scaleMode?: "fit" | "fill";
+    /**
+     * Pixel density of the `<canvas>`.
+     */
+    resolution?: number;
+    /**
+     * Retains canvas drawing on resize, without the need of an animation loop.
+     */
+    static?: boolean;
+};
+/**
+ * @typedef CreateCanvasOptions
+ * @property {HTMLElement} [target=document.body] Where to add the `<canvas>` element in the DOM.
+ * @property {[x: number, y: number, w: number, h: number]} [viewBox=[0, 0, 200, 200]] Canvas viewbox (x, y, w, h). Mirrors SVG Behaviour.
+ * @property {boolean} [autoAspectRatio=true] Match DOM dimensions to `viewBox`. When true, `<canvas>` elements behave in a similar way to `<svg>`.
+ * @property {"fit" | "fill"} [scaleMode='fit'] VBCanvas's version of `preserveAspectRatio`. Accepts `fit` or `fill`. `fit` is equal to SVG'sxMidYMid meet. `fill` is equal to SVG'sxMidYMid slice.
+ * @property {number} [resolution=window.devicePixelRatio] Pixel density of the `<canvas>`.
+ * @property {boolean} [static=false] Retains canvas drawing on resize, without the need of an animation loop.
+ */
+/**
+ * @param {CreateCanvasOptions} opts
+ */
+export function createCanvas(opts: CreateCanvasOptions): {
+    el: HTMLCanvasElement;
+    ctx: CanvasRenderingContext2D;
+};

--- a/dist/types/observeElDimensions.d.ts
+++ b/dist/types/observeElDimensions.d.ts
@@ -1,0 +1,1 @@
+export function observeElDimensions(el: any, callback: any): void;

--- a/dist/types/resizeCanvas.d.ts
+++ b/dist/types/resizeCanvas.d.ts
@@ -1,0 +1,21 @@
+export type ResizeCanvasOptions = {
+    opts: import(".").CreateCanvasOptions;
+    canvasID: string;
+    canvasHTMLElement: HTMLCanvasElement;
+    canvasStyleSheet: CSSStyleSheet;
+    baseContext: CanvasRenderingContext2D;
+    history: ReturnType<typeof import("./createContextHistory").createContextHistory>;
+};
+/**
+ * @typedef ResizeCanvasOptions
+ * @property {import(".").CreateCanvasOptions} opts
+ * @property {string} canvasID
+ * @property {HTMLCanvasElement} canvasHTMLElement
+ * @property {CSSStyleSheet} canvasStyleSheet
+ * @property {CanvasRenderingContext2D} baseContext
+ * @property {ReturnType<typeof import("./createContextHistory").createContextHistory>} history
+ */
+/**
+ * @param {ResizeCanvasOptions} options
+ */
+export function resizeCanvas({ opts, canvasID, canvasHTMLElement, canvasStyleSheet, baseContext, history, }: ResizeCanvasOptions): void;

--- a/dist/types/restoreFromHistory.d.ts
+++ b/dist/types/restoreFromHistory.d.ts
@@ -1,0 +1,1 @@
+export function restoreFromHistory(ctx: any, history: any): void;

--- a/dist/types/setCanvasHTMLElementDimensions.d.ts
+++ b/dist/types/setCanvasHTMLElementDimensions.d.ts
@@ -1,0 +1,8 @@
+export function setCanvasHTMLElementDimensions({ id, el, autoAspectRatio, viewBox, resolution, styleSheet, }: {
+    id: any;
+    el: any;
+    autoAspectRatio: any;
+    viewBox: any;
+    resolution: any;
+    styleSheet: any;
+}): void;

--- a/dist/types/styles.d.ts
+++ b/dist/types/styles.d.ts
@@ -1,0 +1,2 @@
+export function createCanvasStyleSheet(id: any): CSSStyleSheet;
+export function createBaseCanvasStyles(): void;

--- a/dist/types/transformContextMatrix.d.ts
+++ b/dist/types/transformContextMatrix.d.ts
@@ -1,0 +1,6 @@
+export function transformContextMatrix({ ctx, viewBox, resolution, scaleMode }: {
+    ctx: any;
+    viewBox: any;
+    resolution: any;
+    scaleMode: any;
+}): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7313,6 +7313,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
+    },
     "unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "source": "src/index.js",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "types": "dist/types/index.d.ts",
   "version": "0.1.5",
   "description": "",
   "dependencies": {
@@ -19,12 +20,14 @@
     "jest-puppeteer": "^4.4.0",
     "puppeteer": "^5.5.0",
     "rollup": "^2.33.2",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^4.1.2"
   },
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest --watchAll --coverage"
+    "test": "jest --watchAll --coverage",
+    "types": "tsc"
   },
   "keywords": [],
   "author": "",

--- a/src/createContextHistory.js
+++ b/src/createContextHistory.js
@@ -9,6 +9,11 @@ function createContextHistory() {
     get size() {
       return store.size;
     },
+    /**
+     * @param {"function" | "set"} type
+     * @param {string | number | symbol} name
+     * @param {unknown} args
+     */
     push(type, name, args) {
       store.set(position, { type, name, args });
 

--- a/src/createObservableContext.js
+++ b/src/createObservableContext.js
@@ -1,3 +1,7 @@
+/**
+ * @param {CanvasRenderingContext2D} baseContext
+ * @param {ReturnType<typeof import("./createContextHistory").createContextHistory>['push']} observe
+ */
 function createObservableContext(baseContext, observe) {
   return new Proxy(baseContext, {
     get(target, name) {

--- a/src/domUtils.js
+++ b/src/domUtils.js
@@ -15,10 +15,15 @@ function createCanvasHTMLElement(id) {
   return el;
 }
 
+/** @param {HTMLCanvasElement} canvasHTMLElement */
 function getCanvasContext(canvasHTMLElement) {
   return canvasHTMLElement.getContext('2d');
 }
 
+/**
+ * @param {HTMLElement} target
+ * @param {HTMLCanvasElement} el
+ */
 function mountCanvasToDOM(target, el) {
   target.appendChild(el);
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,19 @@ import { createCanvasStyleSheet, createBaseCanvasStyles } from './styles';
 
 createBaseCanvasStyles();
 
+/**
+ * @typedef CreateCanvasOptions
+ * @property {HTMLElement} [target=document.body] Where to add the `<canvas>` element in the DOM.
+ * @property {[x: number, y: number, w: number, h: number]} [viewBox=[0, 0, 200, 200]] Canvas viewbox (x, y, w, h). Mirrors SVG Behaviour.
+ * @property {boolean} [autoAspectRatio=true] Match DOM dimensions to `viewBox`. When true, `<canvas>` elements behave in a similar way to `<svg>`.
+ * @property {"fit" | "fill"} [scaleMode='fit'] VBCanvas's version of `preserveAspectRatio`. Accepts `fit` or `fill`. `fit` is equal to SVG'sxMidYMid meet. `fill` is equal to SVG'sxMidYMid slice.
+ * @property {number} [resolution=window.devicePixelRatio] Pixel density of the `<canvas>`.
+ * @property {boolean} [static=false] Retains canvas drawing on resize, without the need of an animation loop.
+ */
+
+/**
+ * @param {CreateCanvasOptions} opts
+ */
 function createCanvas(opts) {
   opts = Object.assign({}, DEFAULTS, opts);
   opts.target = resolveTarget(opts.target);

--- a/src/resizeCanvas.js
+++ b/src/resizeCanvas.js
@@ -2,6 +2,19 @@ import { setCanvasHTMLElementDimensions } from './setCanvasHTMLElementDimensions
 import { transformContextMatrix } from './transformContextMatrix';
 import { restoreFromHistory } from './restoreFromHistory';
 
+/**
+ * @typedef ResizeCanvasOptions
+ * @property {import(".").CreateCanvasOptions} opts
+ * @property {string} canvasID
+ * @property {HTMLCanvasElement} canvasHTMLElement
+ * @property {CSSStyleSheet} canvasStyleSheet
+ * @property {CanvasRenderingContext2D} baseContext
+ * @property {ReturnType<typeof import("./createContextHistory").createContextHistory>} history
+ */
+
+/**
+ * @param {ResizeCanvasOptions} options
+ */
 function resizeCanvas({
   opts,
   canvasID,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist/types"
+  },
+  "include": ["./src/*.js", "./src/*.d.ts"]
+}


### PR DESCRIPTION
This PR adds TypeScript support to VBCanvas. It has 2 commits:
1. Added JSDocs to some of the functions so it has enough types to work.
2. Added typescript as a devDependency and added a `types` script that generates the types from the JSDocs. This allows you to keep on working on JS without migrating to TS, but to keep your types up-to-date if you make any changes.